### PR TITLE
Allow to pass a timestamp when counter is incremented

### DIFF
--- a/lib/von.rb
+++ b/lib/von.rb
@@ -26,12 +26,12 @@ module Von
     yield(config)
   end
 
-  def self.increment(field, value=1)
+  def self.increment(field, value=1, timestamp=Time.now)
     parents = field.to_s.sub(PARENT_REGEX, '')
-    total   = increment_counts_for(field, value)
+    total   = increment_counts_for(field, value, timestamp)
 
     until parents.empty? do
-      increment_counts_for(parents, value)
+      increment_counts_for(parents, value, timestamp)
       parents.sub!(PARENT_REGEX, '')
     end
 
@@ -40,23 +40,23 @@ module Von
     raise e if config.raise_connection_errors
   end
 
-  def self.increment_counts_for(field, value=1)
+  def self.increment_counts_for(field, value=1, timestamp=Time.now)
     counter = Counters::Total.new(field)
     total   = counter.increment(value)
 
     if config.periods_defined_for_counter?(counter)
       periods = config.periods[counter.field]
-      Counters::Period.new(counter.field, periods).increment(value)
+      Counters::Period.new(counter.field, periods).increment(value, timestamp)
     end
 
     if config.bests_defined_for_counter?(counter)
       periods = config.bests[counter.field]
-      Counters::Best.new(counter.field, periods).increment(value)
+      Counters::Best.new(counter.field, periods).increment(value, timestamp)
     end
 
     if config.currents_defined_for_counter?(counter)
       periods = config.currents[counter.field]
-      Counters::Current.new(counter.field, periods).increment(value)
+      Counters::Current.new(counter.field, periods).increment(value, timestamp)
     end
 
     total

--- a/lib/von/counters/best.rb
+++ b/lib/von/counters/best.rb
@@ -28,17 +28,17 @@ module Von
         hget("#{hash_key}:#{time_unit}:current", 'timestamp')
       end
 
-      def increment(value=1)
+      def increment(value=1, timestamp=Time.now)
         return if @periods.empty?
 
         @periods.each do |period|
           _current_timestamp = current_timestamp(period.time_unit)
           _current_total     = current_total(period.time_unit)
 
-          if period.timestamp != _current_timestamp
+          if period.timestamp(timestamp) != _current_timestamp
             # changing current period
             hset("#{hash_key}:#{period.time_unit}:current", 'total', value)
-            hset("#{hash_key}:#{period.time_unit}:current", 'timestamp', period.timestamp)
+            hset("#{hash_key}:#{period.time_unit}:current", 'timestamp', period.timestamp(timestamp))
 
             if best_total(period) < _current_total
               hset("#{hash_key}:#{period.time_unit}:best", 'total', _current_total)

--- a/lib/von/counters/current.rb
+++ b/lib/von/counters/current.rb
@@ -20,13 +20,13 @@ module Von
         hget("#{hash_key}:#{time_unit}", 'timestamp')
       end
 
-      def increment(value=1)
+      def increment(value=1, timestamp=Time.now)
         return if @periods.empty?
 
         @periods.each do |period|
-          if period.timestamp != current_timestamp(period.time_unit)
+          if period.timestamp(timestamp) != current_timestamp(period.time_unit)
             hset("#{hash_key}:#{period.time_unit}", 'total', value)
-            hset("#{hash_key}:#{period.time_unit}", 'timestamp', period.timestamp)
+            hset("#{hash_key}:#{period.time_unit}", 'timestamp', period.timestamp(timestamp))
           else
             hincrby("#{hash_key}:#{period.time_unit}", 'total', value)
           end

--- a/lib/von/counters/period.rb
+++ b/lib/von/counters/period.rb
@@ -18,17 +18,17 @@ module Von
         "#{Von.config.namespace}:lists:#{@field}:#{time_unit}"
       end
 
-      def increment(value=1)
+      def increment(value=1, timestamp=Time.now)
         return if @periods.empty?
 
         @periods.each do |period|
           _hash_key = hash_key(period.time_unit)
           _list_key = list_key(period.time_unit)
 
-          hincrby(_hash_key, period.timestamp, value)
+          hincrby(_hash_key, period.timestamp(timestamp), value)
 
-          unless lrange(_list_key, 0, -1).include?(period.timestamp)
-            rpush(_list_key, period.timestamp)
+          unless lrange(_list_key, 0, -1).include?(period.timestamp(timestamp))
+            rpush(_list_key, period.timestamp(timestamp))
           end
 
           if llen(_list_key) > period.length

--- a/lib/von/counters/total.rb
+++ b/lib/von/counters/total.rb
@@ -21,7 +21,7 @@ module Von
       # If the key has time periods specified, increment those.
       #
       # Returns the Integer total for the key
-      def increment(value=1)
+      def increment(value=1, timestamp=nil)
         hincrby(hash_key, 'total', value).to_i
       end
 

--- a/lib/von/period.rb
+++ b/lib/von/period.rb
@@ -61,8 +61,8 @@ module Von
       beginning(unit.send(time_unit.to_sym).ago).strftime(@format)
     end
 
-    def timestamp
-      beginning(Time.now).strftime(format)
+    def timestamp(time=Time.now)
+      beginning(time).strftime(format)
     end
 
     def self.unit_to_period(time_unit)

--- a/test/counters/best_test.rb
+++ b/test/counters/best_test.rb
@@ -15,10 +15,8 @@ describe Von::Counters::Best do
 
     counter.increment
 
-    Timecop.freeze(Time.local(2013, 01, 02))
-    4.times { counter.increment(2) }
-    Timecop.freeze(Time.local(2013, 01, 03))
-    3.times { counter.increment }
+    4.times { counter.increment(2, Time.local(2013, 01, 02)) }
+    3.times { counter.increment(1, Time.local(2013, 01, 03)) }
 
     @redis.hget('von:counters:bests:foo:day:current', 'timestamp').must_equal '2013-01-03'
     @redis.hget('von:counters:bests:foo:day:current', 'total').must_equal '3'
@@ -34,10 +32,8 @@ describe Von::Counters::Best do
 
     counter.increment
 
-    Timecop.freeze(Time.local(2013, 01, 13, 06, 05))
-    4.times { counter.increment(2) }
-    Timecop.freeze(Time.local(2013, 01, 20, 06, 10))
-    3.times { counter.increment }
+    4.times { counter.increment(2, Time.local(2013, 01, 13, 06, 05)) }
+    3.times { counter.increment(1, Time.local(2013, 01, 20, 06, 10)) }
 
     @redis.hget('von:counters:bests:foo:minute:current', 'timestamp').must_equal '2013-01-20 06:10'
     @redis.hget('von:counters:bests:foo:minute:current', 'total').must_equal '3'

--- a/test/counters/current_test.rb
+++ b/test/counters/current_test.rb
@@ -14,8 +14,7 @@ describe Von::Counters::Current do
     counter = CurrentCounter.new('foo', [ Von::Period.new(:day) ])
 
     4.times { counter.increment }
-    Timecop.freeze(Time.local(2013, 01, 02))
-    3.times { counter.increment(2) }
+    3.times { counter.increment(2, Time.local(2013, 01, 02)) }
 
     @redis.hget('von:counters:currents:foo:day', 'timestamp').must_equal '2013-01-02'
     @redis.hget('von:counters:currents:foo:day', 'total').must_equal '6'
@@ -28,8 +27,7 @@ describe Von::Counters::Current do
     ])
 
     4.times { counter.increment }
-    Timecop.freeze(Time.local(2013, 01, 20, 06, 10))
-    3.times { counter.increment(2) }
+    3.times { counter.increment(2, Time.local(2013, 01, 20, 06, 10)) }
 
     @redis.hget('von:counters:currents:foo:minute', 'timestamp').must_equal '2013-01-20 06:10'
     @redis.hget('von:counters:currents:foo:minute', 'total').must_equal '6'
@@ -45,8 +43,7 @@ describe Von::Counters::Current do
     ])
 
     4.times { counter.increment }
-    Timecop.freeze(Time.local(2013, 01, 01, 06, 10))
-    3.times { counter.increment(2) }
+    3.times { counter.increment(2, Time.local(2013, 01, 01, 06, 10)) }
 
     counter.count(:minute).must_equal 6
     counter.count(:day).must_equal 10


### PR DESCRIPTION
I though it should be nice to have possibility to add custom timestamp to counter when incrementing it's value (e.g. to be able to populate the data or migrate from other storage). In my implementation, you can pass a timestamp as `Von.increment` argument. `Time.now` is assumed when timestamp is not present.

Related issue: #10
