### PR TITLE
activesupport compatibility

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ Bundler.setup
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'fakeredis'
-require 'mocha'
+require 'mocha/mini_test'
 require 'timecop'
 
 require 'von'

--- a/von.gemspec
+++ b/von.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency 'redis', '~> 3.0.2'
-  gem.add_dependency 'activesupport', '~> 3.2.11'
+  gem.add_dependency 'activesupport', '~> 4.1.0'
 
   gem.add_development_dependency 'rake', '>= 10.0.3'
   gem.add_development_dependency 'minitest', '>= 3.0.0'


### PR DESCRIPTION
Hi,

I had some compatibility issues with activesupport 4.1.

I've updated the gemspec.
I've also fixed the mocha import in the test helper.

The test are passing but it may need more testing.
